### PR TITLE
Unicode, whitespace capture option, escape html

### DIFF
--- a/src/SimpleDiff.php
+++ b/src/SimpleDiff.php
@@ -67,6 +67,7 @@ class SimpleDiff
      */
     public static function htmlDiff($old, $new, $ws = true) {
         $ret = '';
+        $spacer = '';
         if ($ws) {
             $diff = self::diff(
                 preg_split('/(\s+)/u', $old, null, PREG_SPLIT_DELIM_CAPTURE),
@@ -74,6 +75,7 @@ class SimpleDiff
             );
         }
         else {
+            $spacer = ' ';
             $diff = self::diff(
                 preg_split('/\s+/u', $old),
                 preg_split('/\s+/u', $new)
@@ -84,17 +86,17 @@ class SimpleDiff
                 foreach (['deleted', 'inserted'] as $v) {
                     $$v = '';
                     if (!empty($k[$v])) {
-                        $$v = implode('', $k[$v]);
+                        $$v = implode($spacer, $k[$v]);
                         if ($$v != '') {
                             $tag = substr($v, 0, 3);
-                            $$v = "<$tag>" . htmlspecialchars($$v) . "</$tag>" . ($ws ? '' : ' ');
+                            $$v = "<$tag>" . htmlspecialchars($$v) . "</$tag>$spacer";
                         }
                     }
                 }
                 $ret .= $deleted . $inserted;
             }
             else {
-                $ret .= htmlspecialchars($k) . ($ws ? '' : ' ');
+                $ret .= htmlspecialchars($k) . $spacer;
             }
         }
         return $ret;

--- a/src/SimpleDiff.php
+++ b/src/SimpleDiff.php
@@ -61,16 +61,24 @@ class SimpleDiff
      *
      * @param  string $old  Original string to compare to
      * @param  string $new  New string to compare against
+     * @param  bool   $ws   Whether to include whitespace in diff
      *
      * @return string       Combination of both strings with <ins> and <del> tags to indicate differences
      */
-    public static function htmlDiff($old, $new)
-    {
+    public static function htmlDiff($old, $new, $ws = true) {
         $ret = '';
-        $diff = self::diff(
-            preg_split("/([\s]+)/", $old, null, PREG_SPLIT_DELIM_CAPTURE),
-            preg_split("/([\s]+)/", $new, null, PREG_SPLIT_DELIM_CAPTURE)
-        );
+        if ($ws) {
+            $diff = self::diff(
+                preg_split('/(\s+)/u', $old, null, PREG_SPLIT_DELIM_CAPTURE),
+                preg_split('/(\s+)/u', $new, null, PREG_SPLIT_DELIM_CAPTURE)
+            );
+        }
+        else {
+            $diff = self::diff(
+                preg_split('/\s+/u', $old),
+                preg_split('/\s+/u', $new)
+            );
+        }
         foreach ($diff as $k) {
             if (is_array($k)) {
                 foreach (['deleted', 'inserted'] as $v) {
@@ -79,13 +87,14 @@ class SimpleDiff
                         $$v = implode('', $k[$v]);
                         if ($$v != '') {
                             $tag = substr($v, 0, 3);
-                            $$v = "<$tag>".$$v."</$tag>";
+                            $$v = "<$tag>" . htmlspecialchars($$v) . "</$tag>" . ($ws ? '' : ' ');
                         }
                     }
                 }
-                $ret .= $deleted.$inserted;
-            } else {
-                $ret .= $k;
+                $ret .= $deleted . $inserted;
+            }
+            else {
+                $ret .= htmlspecialchars($k) . ($ws ? '' : ' ');
             }
         }
         return $ret;


### PR DESCRIPTION
A few fixes for some issues I ran into using htmlDiff:

1. Adds explicit unicode modifier to the regex.
2. Escapes html tags in diff'd text on output.
3. Adds a flag to optionally disable whitespace capture (like the original Paul's Simple Diff Algorithm).